### PR TITLE
Atlas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,15 @@ ARG TF_FILE=tensorflow-1.7.0-cp27-none-any.whl
 COPY pip.conf /etc/pip.conf
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    gfortran \
     curl \
     libfreetype6-dev \
     libpng12-dev \
     libzmq3-dev \
     pkg-config \
     python \
+    python-dev \
     python-pip \
     python-setuptools \
     python-h5py \
@@ -34,12 +37,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # RUN pip install --upgrade pip && \ # Replaced as ericflores suggested https://github.com/DeftWork/rpi-tensorflow/issues/5#issuecomment-381374497
 RUN pip install --upgrade pip==9.0.3 && \
-     pip install  'numpy>=1.13.3' scipy matplotlib sklearn pandas && \
-     pip install tensorflow==1.7.0 && \
-     pip install ipykernel jupyterlab && \
+     pip install --upgrade \
+     grpcio==1.11.0 \
+     kiwisolver==1.0.1  \
+     MarkupSafe==1.0 \
+     pyzmq==17.0.0 \
+     scandir==1.7 \
+     subprocess32==3.2.7 \
+     tornado==5.0.2 \
+     numpy==1.14.2 \
+     scipy==1.0.1 \
+     matplotlib==2.2.2 \
+     pandas==0.22.0 \
+     scikit_learn==0.19.1 \
+     tensorflow==1.7.0 \
+     ipykernel \
+     jupyterlab && \
      python -m ipykernel.kernelspec && \
-     rm -rf /wheels &&\
-     date
+     rm -rf /wheels
 
 COPY jupyter_notebook_config.py /root/.jupyter/
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ There is very similar image based on Python 3.4 instead of 2.7 [elswork/rpi-tens
 
 - Upgraded from Tensorflow 1.7.0rc1 to 1.7.0
 - Implementation of the Keras API
+- Included ALTAS optimized BLAS libraries and compiled versions of packages (numpy, scipy) using them.
 
 ### 1.7.0 rc1
 

--- a/README.md
+++ b/README.md
@@ -110,3 +110,9 @@ tensorboard --logdir=path/to/log-directory --host=0.0.0.0
 ```
 
 And pointing your browser to `http://localhost:6006`
+
+After the container is running you can use the Jupyter upload feature to copy notebooks and other small files to the container. However, it is not possible to load files larger than 15MB using the Jupyter interface. If you want to transfer multi-megabyte files like models generated in a more powerful machine, you can use docker cp command as follows:
+
+```sh
+docker cp mybigmodel.tf container_name:/notebooks/mybigmodel.tf
+```


### PR DESCRIPTION
Now each compiled python package specifies the version number. In this way the Docker image will continue building even if newer version of those packages are released. Yet, included the the development tools (build-essential, gfortran, python-dev) so that it includes the tools required to compile any new package.